### PR TITLE
corsでのCookie送信を避ける

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,17 @@ const nextConfig = {
 
     return compilerConfig
   })(),
+  async rewrites() {
+    return [
+      {
+        // ex. /api/proxy
+        source: `${process.env.NEXT_PUBLIC_API_BASE_PATH}/:match`,
+        // ex. http://localhost:8000
+        destination: `${process.env.API_BASE_URL}/:match*`,
+
+      },
+    ]
+  }
 }
 
 module.exports = nextConfig


### PR DESCRIPTION
これでcookieを別オリジンに送らないで済むということに